### PR TITLE
Fix available seat calculation

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -30,7 +30,7 @@ async function execute() {
                 preReq,
                 element.defaultSeatCapacity,
                 element.totalFillupSeat,
-                element.availableSeat,
+                element.defaultSeatCapacity - element.totalFillupSeat,
                 classScheduleArray.join("\n"),
                 filteredLabSchedule.join("\n"),
                 element.dayNo


### PR DESCRIPTION
Now matches with the USIS portal. 

Not sure what's the purpose of `availableSeat` is but it's static and can be more than `defaultSeatCapacity` too.